### PR TITLE
Fix failed compilation from possible syntax errors

### DIFF
--- a/src/main/java/com/example/example_mod/mixin/TitleScreenMixin.java
+++ b/src/main/java/com/example/example_mod/mixin/TitleScreenMixin.java
@@ -11,6 +11,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class TitleScreenMixin {
 	@Inject(method = "init", at = @At("TAIL"))
 	public void exampleMod$onInit(CallbackInfo ci) {
-		ExampleMod.Companion.getLOGGER().info("This line is printed by an example mod mixin!");
+		ExampleMod.INSTANCE.getLOGGER().info("This line is printed by an example mod mixin!");
 	}
 }

--- a/src/main/kotlin/com/example/example_mod/ExampleMod.kt
+++ b/src/main/kotlin/com/example/example_mod/ExampleMod.kt
@@ -6,7 +6,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 object ExampleMod : ModInitializer {
-    private val LOGGER: Logger = LoggerFactory.getLogger("Example Mod")
+    val LOGGER: Logger = LoggerFactory.getLogger("Example Mod")
 
     override fun onInitialize(mod: ModContainer) {
         LOGGER.info("Hello Quilt world from {}!", mod.metadata()?.name())

--- a/src/main/kotlin/com/example/example_mod/ExampleMod.kt
+++ b/src/main/kotlin/com/example/example_mod/ExampleMod.kt
@@ -10,6 +10,6 @@ class ExampleMod : ModInitializer {
         LOGGER.info("Hello Quilt world from {}!", mod.metadata()?.name())
     }
     companion object {
-        private val LOGGER: Logger = LoggerFactory.getLogger("Example Mod")
+        val LOGGER: Logger = LoggerFactory.getLogger("Example Mod")
     }
 }

--- a/src/main/kotlin/com/example/example_mod/ExampleMod.kt
+++ b/src/main/kotlin/com/example/example_mod/ExampleMod.kt
@@ -5,10 +5,11 @@ import org.quiltmc.qsl.base.api.entrypoint.ModInitializer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-object ExampleMod : ModInitializer {
-    private val LOGGER: Logger = LoggerFactory.getLogger("Example Mod")
-
+class ExampleMod : ModInitializer {
     override fun onInitialize(mod: ModContainer) {
         LOGGER.info("Hello Quilt world from {}!", mod.metadata()?.name())
+    }
+    companion object {
+        private val LOGGER: Logger = LoggerFactory.getLogger("Example Mod")
     }
 }

--- a/src/main/kotlin/com/example/example_mod/ExampleMod.kt
+++ b/src/main/kotlin/com/example/example_mod/ExampleMod.kt
@@ -5,11 +5,10 @@ import org.quiltmc.qsl.base.api.entrypoint.ModInitializer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-class ExampleMod : ModInitializer {
+object ExampleMod : ModInitializer {
+    private val LOGGER: Logger = LoggerFactory.getLogger("Example Mod")
+
     override fun onInitialize(mod: ModContainer) {
         LOGGER.info("Hello Quilt world from {}!", mod.metadata()?.name())
-    }
-    companion object {
-        private val LOGGER: Logger = LoggerFactory.getLogger("Example Mod")
     }
 }

--- a/src/main/kotlin/com/example/example_mod/ExampleMod.kt
+++ b/src/main/kotlin/com/example/example_mod/ExampleMod.kt
@@ -10,6 +10,6 @@ class ExampleMod : ModInitializer {
         LOGGER.info("Hello Quilt world from {}!", mod.metadata()?.name())
     }
     companion object {
-        val LOGGER: Logger = LoggerFactory.getLogger("Example Mod")
+        private val LOGGER: Logger = LoggerFactory.getLogger("Example Mod")
     }
 }

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -19,7 +19,10 @@
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
     "entrypoints": {
-      "init": "com.example.example_mod.ExampleMod"
+      "init": {
+				"adapter": "kotlin",
+				"value": "com.example.example_mod.ExampleMod"
+			}
     },
     "depends": [
       {


### PR DESCRIPTION
In the current state of this template, simply cloning it and running the runClient task fails with a compilation error, due to ExampleMod being declared an object instead of a class. I detected this as being unintentional because in TitleScreenMixin, the mixin attempts to access ExampleMod.Companion, indicating that the LOGGER variable should be contained within the companion object of a class instead of within an object. It also seems like it should not be private or else TitleScreenMixin cannot access it. The fix declares ExampleMod as a class instead of an object, moves LOGGER into ExampleMod's companion object, and removes the private modifier from LOGGER.