### PR TITLE
Fix various gradle buildscript issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,6 @@ org.gradle.parallel=true
 kotlin.incremental=true
 kotlin.code.style=official
 
+group=com.example
 version=1.0.0
 archives_base_name=quilt-kotlin-template-mod


### PR DESCRIPTION
Based on commentary in the toolchain discord:

- someone did strict version instead of required version lol
- why on earth does remapJar depend on remapSourcesJar
- also you're declaring source/javadoc jars twice
- and double-declaring those in the maven publication
- the publishing repositories {} block doesn't have to be in publications {}
- version is redundantly redeclared from the version field in gradle.properties
- the group isn't in gradle.properties, which doesn't match the readme
- incremental compilation is done by default, you don't need to manually request it
- you'll probably want to declare a UTF-8 encoding for resource processing and JD too, not just java compilation

not changed bc i'm not sure which way yall want to go:

- lol there's inconsistent tabs/spaces in the QMJ too
- also inconsistent tabs/spaces between kotlin and java parts of the source
- this editorconfig isn't even updated for kotlin buildscripts smh