### PR TITLE
:bug: updates `quilt_loader` version to a more recent one

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "1.8.22"
 minecraft = "1.20.1"
 qfapi = "7.0.3+0.83.1-1.20.1"
 qkl = "2.1.0+kt.1.8.22+flk.1.9.4"
-loader = "0.19.1"
+loader = "0.28.1"
 mappings = "1.20.1+build.1"
 loom = "1.2.3"
 

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -27,7 +27,7 @@
 		"depends": [
 			{
 				"id": "quilt_loader",
-				"versions": ">=0.19.2"
+				"versions": ">=0.28.1"
 			},
 			{
 				"id": "quilted_fabric_api",


### PR DESCRIPTION
Currently, cloning/using the template and running the `runClient` task fails.
The reason being that `quilt.mod.json` requires `quilt_loader` to be of version 0.19.2 or earlier (`>=0.19.2`) but `libs.versions.toml` sets it to version `0.19.1`.

This commit fixes that and updates it to the currently latest version 0.28.1:
![image](https://github.com/user-attachments/assets/3d75d2c8-8cd3-464c-938a-ae799b220815)
